### PR TITLE
Comm msg rpc

### DIFF
--- a/juno_magic/bridge.py
+++ b/juno_magic/bridge.py
@@ -97,6 +97,12 @@ def build_bridge_class(client):
         def list(self):
             return list(self.prefix_list)
 
+        @wamp.register(u"io.timbr.kernel.{}.comm_msg".format(_key))
+        def comm_msg(self, *args, **kwargs):
+            msg = kwargs.get('msg', {})
+            log.msg("[comm_msg] {}".format(pformat(json_clean(msg))))
+            return client.shell_channel.send(msg)
+
         @inlineCallbacks
         def proxy_iopub_channel(self):
             while True:

--- a/juno_magic/bridge.py
+++ b/juno_magic/bridge.py
@@ -97,6 +97,8 @@ def build_bridge_class(client):
         def list(self):
             return list(self.prefix_list)
 
+        # This is relies heavily on shell_channel property on the client
+        # need to pay attention to Jupyter.client if/when this changes...
         @wamp.register(u"io.timbr.kernel.{}.comm_msg".format(_key))
         def comm_msg(self, *args, **kwargs):
             msg = kwargs.get('msg', {})


### PR DESCRIPTION
Relays messages of type `comm_msg` over the shell_channel via an RPC wamp endpoint. Used to provide a means for comm messages to be passed over wamp and forwarded to zeromq
