### PR TITLE
Suicide

### DIFF
--- a/juno_magic/bridge.py
+++ b/juno_magic/bridge.py
@@ -246,7 +246,7 @@ def main():
     parser.add_argument("--token", type=unicode, help="OAuth token to connect to router")
     parser.add_argument("--auto-shutdown", action="store_true",
                         default=False, help="When set, disconnect and cleanup Wamp session when heartbeat times out and then stop the IOLoop")
-    parser.add_argument("--hb-interval", type=int, default=30, help="The heartbeat interval used when auto-shutdown is set")
+    parser.add_argument("--hb-interval", type=int, default=120, help="The heartbeat interval used when auto-shutdown is set")
     parser.add_argument("file", help="Connection file")
     args = parser.parse_args()
 

--- a/juno_magic/bridge.py
+++ b/juno_magic/bridge.py
@@ -298,13 +298,19 @@ def main():
                             returnValue(res)
                     yield sleep(5.0)
             except ConnectionRefusedError as ce:
+#                if hb is not None and hb.running:
+#                    hb.stop()
+#                log.msg("ConnectionRefusedError: Trying to reconnect... ")
+#                yield sleep(1.0)
                 if hb is not None and hb.running:
                     hb.stop()
-                log.msg("ConnectionRefusedError: Trying to reconnect... ")
-                yield sleep(1.0)
+                log.msg("Commiting suicide in 15 seconds")
+                yield sleep(15.0)
+                returnValue(res)
 
     @inlineCallbacks
     def shutdown(result):
+        log.msg("Comitting suicide")
         yield IOLoop.current().stop()
         exec "circusctl quit" in globals(), locals()
 

--- a/juno_magic/bridge.py
+++ b/juno_magic/bridge.py
@@ -310,8 +310,13 @@ def main():
 
     def shutdown(result):
         log.msg("Comitting suicide")
-        IOLoop.current().stop()
-        exec "circusctl quit" in globals(), locals()
+        #IOLoop.current().stop()
+        import subprocess
+        proc = subprocess.Popen(["python", "-m", "circus.ctl", "quit"],
+                                stdin=subprocess.PIPE,
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE)
+
 
     d = reconnector(args.shutdown_interval)
     d.addCallback(shutdown)

--- a/juno_magic/bridge.py
+++ b/juno_magic/bridge.py
@@ -306,7 +306,7 @@ def main():
     @inlineCallbacks
     def shutdown(result):
         yield IOLoop.current().stop()
-        exec("circusctl quit")
+        exec "circusctl quit" in globals(), locals()
 
     d = reconnector(args.shutdown_interval)
     d.addCallback(shutdown)

--- a/juno_magic/bridge.py
+++ b/juno_magic/bridge.py
@@ -310,9 +310,9 @@ def main():
 
     def shutdown(result):
         log.msg("Comitting suicide")
-        #IOLoop.current().stop()
+        IOLoop.current().stop()
         import subprocess
-        proc = subprocess.Popen(["python", "-m", "circus.ctl", "quit"],
+        proc = subprocess.Popen(["python", "-m", "circus.circusctl", "quit"],
                                 stdin=subprocess.PIPE,
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE)

--- a/juno_magic/bridge.py
+++ b/juno_magic/bridge.py
@@ -172,6 +172,7 @@ def build_bridge_class(client):
                 response = False
             finally:
                 log.msg("PINGED from WAMPIFY NETWORK: returned {}".format(response))
+                returnValue(response)
 
         def on_discovery(self, prefix):
             self.prefix_list.add(prefix)

--- a/juno_magic/bridge.py
+++ b/juno_magic/bridge.py
@@ -244,7 +244,7 @@ def main():
     parser.add_argument("--wamp-realm", default=u"jupyter", help='Router realm')
     parser.add_argument("--wamp-url", default=u"ws://127.0.0.1:8123", help="WAMP Websocket URL")
     parser.add_argument("--token", type=unicode, help="OAuth token to connect to router")
-    parser.add_argument("--shutdown-interval", default=0, help="When set to positive non-zero value, shutdown remote processes after shutdown_interval number of seconds of no pings")
+    parser.add_argument("--shutdown-interval", type=int, default=0, help="When set to positive non-zero value, shutdown remote processes after shutdown_interval number of seconds of no pings")
     parser.add_argument("file", help="Connection file")
     args = parser.parse_args()
 

--- a/juno_magic/bridge.py
+++ b/juno_magic/bridge.py
@@ -160,14 +160,14 @@ def build_bridge_class(client):
             log.msg("PINGED from EXTERNAL APPLICATION: returned {}".format(response))
             return response
 
-        @wamp.register(u"io.timbr.kernel.{}._ping".format(_key))
-        def _ping(self):
+        @wamp.register(u"io.timbr.kernel.{}.nw_ping".format(_key))
+        def nw_ping(self):
             return client.is_alive()
 
         @inlineCallbacks
         def is_active(self, prefix):
             try:
-                response = yield self.call(u"{}._ping".format(prefix))
+                response = yield self.call(u"{}.nw_ping".format(prefix))
             except ApplicationError:
                 response = False
             finally:

--- a/juno_magic/bridge.py
+++ b/juno_magic/bridge.py
@@ -301,9 +301,10 @@ def main():
                 log.msg("ConnectionRefusedError: Trying to reconnect... ")
                 yield sleep(1.0)
 
-
+    @inlineCallbacks
     def shutdown(result):
-        IOLoop.current().stop()
+        yield IOLoop.current().stop()
+        exec("circusctl quit")
 
     d = reconnector(args.auto_shutdown)
     d.addCallback(shutdown)

--- a/juno_magic/bridge.py
+++ b/juno_magic/bridge.py
@@ -167,7 +167,6 @@ def build_bridge_class(client):
         def is_active(self, prefix):
             try:
                 response = yield self.call(u"{}._ping".format(prefix))
-                returnValue(response)
             except ApplicationError:
                 response = False
             finally:

--- a/juno_magic/bridge.py
+++ b/juno_magic/bridge.py
@@ -244,8 +244,7 @@ def main():
     parser.add_argument("--wamp-realm", default=u"jupyter", help='Router realm')
     parser.add_argument("--wamp-url", default=u"ws://127.0.0.1:8123", help="WAMP Websocket URL")
     parser.add_argument("--token", type=unicode, help="OAuth token to connect to router")
-    parser.add_argument("--shutdown-interval", default=0, help="When set, disconnect and cleanup Wamp session when heartbeat times out and then stop the IOLoop")
-    parser.add_argument("--hb-interval", type=int, default=120, help="The heartbeat interval used when auto-shutdown is set")
+    parser.add_argument("--shutdown-interval", default=0, help="When set to positive non-zero value, shutdown remote processes after shutdown_interval number of seconds of no pings")
     parser.add_argument("file", help="Connection file")
     args = parser.parse_args()
 
@@ -309,8 +308,7 @@ def main():
         yield IOLoop.current().stop()
         exec("circusctl quit")
 
-    assert args.shutdown_interval >= 0
-    d = reconnector(args.auto_shutdown)
+    d = reconnector(args.shutdown_interval)
     d.addCallback(shutdown)
     # start the tornado io loop
     IOLoop.current().start()

--- a/juno_magic/bridge.py
+++ b/juno_magic/bridge.py
@@ -298,15 +298,10 @@ def main():
                             returnValue(res)
                     yield sleep(5.0)
             except ConnectionRefusedError as ce:
-#                if hb is not None and hb.running:
-#                    hb.stop()
-#                log.msg("ConnectionRefusedError: Trying to reconnect... ")
-#                yield sleep(1.0)
                 if hb is not None and hb.running:
                     hb.stop()
-                log.msg("Commiting suicide in 15 seconds")
-                yield sleep(15.0)
-                returnValue(True)
+                log.msg("ConnectionRefusedError: Trying to reconnect... ")
+                yield sleep(1.0)
 
     def shutdown(result):
         log.msg("Comitting suicide")

--- a/juno_magic/bridge.py
+++ b/juno_magic/bridge.py
@@ -308,10 +308,9 @@ def main():
                 yield sleep(15.0)
                 returnValue(True)
 
-    @inlineCallbacks
     def shutdown(result):
         log.msg("Comitting suicide")
-        #yield IOLoop.current().stop()
+        IOLoop.current().stop()
         exec "circusctl quit" in globals(), locals()
 
     d = reconnector(args.shutdown_interval)

--- a/juno_magic/bridge.py
+++ b/juno_magic/bridge.py
@@ -157,7 +157,7 @@ def build_bridge_class(client):
         def ping(self):
             self._has_been_pinged = True
             response =  client.is_alive()
-            log.msg("PINGED from EXTERNAL APPLICATION: returned {}".format(response))
+#            log.msg("PINGED from EXTERNAL APPLICATION: returned {}".format(response))
             return response
 
         @wamp.register(u"io.timbr.kernel.{}.nw_ping".format(_key))
@@ -171,7 +171,7 @@ def build_bridge_class(client):
             except ApplicationError:
                 response = False
             finally:
-                log.msg("PINGED from WAMPIFY NETWORK: returned {}".format(response))
+#                log.msg("PINGED from WAMPIFY NETWORK: returned {}".format(response))
                 returnValue(response)
 
         def on_discovery(self, prefix):

--- a/juno_magic/bridge.py
+++ b/juno_magic/bridge.py
@@ -158,6 +158,7 @@ def build_bridge_class(client):
             self._has_been_pinged = True
             response =  client.is_alive()
             log.msg("PINGED from EXTERNAL APPLICATION: returned {}".format(response))
+            return response
 
         @wamp.register(u"io.timbr.kernel.{}._ping".format(_key))
         def _ping(self):

--- a/juno_magic/bridge.py
+++ b/juno_magic/bridge.py
@@ -306,12 +306,12 @@ def main():
                     hb.stop()
                 log.msg("Commiting suicide in 15 seconds")
                 yield sleep(15.0)
-                returnValue(res)
+                returnValue(True)
 
     @inlineCallbacks
     def shutdown(result):
         log.msg("Comitting suicide")
-        yield IOLoop.current().stop()
+        #yield IOLoop.current().stop()
         exec "circusctl quit" in globals(), locals()
 
     d = reconnector(args.shutdown_interval)

--- a/juno_magic/extensions/wamp.py
+++ b/juno_magic/extensions/wamp.py
@@ -217,7 +217,8 @@ def build_bridge_class(magics_instance):
                 yield self.set_prefix(magics_instance._kernel_prefix)
                 print("Reconnected to kernel prefix {}".format(magics_instance._kernel_prefix))
             if not magics_instance._heartbeat.running:
-                magics_instance._heartbeat.start(magics_instance._hb_interval, now=False)
+#                magics_instance._heartbeat.start(magics_instance._hb_interval, now=False)
+                pass
             returnValue(None)
 
         @inlineCallbacks
@@ -543,7 +544,8 @@ class JunoMagics(Magics):
         if kernel != self._kernel_prefix:
             yield _select(kernel)
             if not self._heartbeat.running:
-                self._heartbeat.start(self._hb_interval)
+#                self._heartbeat.start(self._hb_interval)
+                pass
         else:
             print("Kernel already selected")
 


### PR DESCRIPTION
new bridge will kill itself if runtime arg shutdown_interval > 0 and the bridge receives no pings from outside application in that timeframe. if running in a docker container under circus pid 1, will kill that container will exit code 0. wampify no longer hits the rpc ping method on remote kernels to facilitate this functionality